### PR TITLE
fix: resolve Dependabot security vulnerabilities via npm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"
   },
+  "overrides": {
+    "loader-utils": "^2.0.4",
+    "minimatch": "^3.1.2",
+    "decode-uri-component": "^0.2.2",
+    "json5": "^2.2.3"
+  },
   "devDependencies": {
     "@angular-devkit/build-angular": "~13.3.7",
     "@angular/cli": "~13.3.7",


### PR DESCRIPTION
Fixes #5

## Summary

- Add `overrides` section to `package.json` to force secure versions of vulnerable transitive dependencies
- Fixes CVE-2022-37601 (loader-utils Prototype Pollution - Critical)
- Fixes CVE-2022-3517 (minimatch ReDoS - High)
- Fixes CVE-2022-38900 (decode-uri-component DoS - High)
- Fixes CVE-2022-46175 (json5 Prototype Pollution - High)

## After Merging

Run `npm install` to regenerate `package-lock.json` with the secure versions.

Generated with [Claude Code](https://claude.ai/code)