### PR TITLE
feat: add spinning pokeball loader when pokemon cards are loading

### DIFF
--- a/src/app/pokedex-container/pokedex-container.component.html
+++ b/src/app/pokedex-container/pokedex-container.component.html
@@ -1,3 +1,3 @@
 <div class="container pokedex">
-<pokedex-dashboard [pokemonList]="pokemonList"></pokedex-dashboard>
+<pokedex-dashboard [pokemonList]="pokemonList" [isLoading]="isLoading"></pokedex-dashboard>
 </div>

--- a/src/app/pokedex-container/pokedex-container.component.ts
+++ b/src/app/pokedex-container/pokedex-container.component.ts
@@ -8,7 +8,7 @@ import  {PokedexDashboardService} from '../pokedex-dashboard/passenger-dahsboard
 })
 export class PokedexContainerComponent implements OnInit {
   pokemonList: any[] = [];
-
+  isLoading = true;
 
   constructor(private pokedexService: PokedexDashboardService, private ngZone: NgZone) { }
 
@@ -16,6 +16,7 @@ export class PokedexContainerComponent implements OnInit {
     this.pokedexService.getPokemon().subscribe((pokemonList) => {
       this.ngZone.run(() => {
         this.pokemonList = pokemonList;
+        this.isLoading = false;
       });
     });
   }

--- a/src/app/pokedex-dashboard/container/pokedex-dashboard/pokedex-dashboard.component.html
+++ b/src/app/pokedex-dashboard/container/pokedex-dashboard/pokedex-dashboard.component.html
@@ -1,4 +1,15 @@
-<ul *ngIf="pokemonList && pokemonList.length > 0" class="pokemon-results">
+<div *ngIf="isLoading" class="loader-container">
+  <svg class="pokeball-loader" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="50" cy="50" r="48" fill="white" stroke="black" stroke-width="4"/>
+    <path d="M2 50 Q2 2 50 2 Q98 2 98 50 Z" fill="#e3350d"/>
+    <rect x="2" y="44" width="96" height="12" fill="black"/>
+    <circle cx="50" cy="50" r="12" fill="white" stroke="black" stroke-width="4"/>
+    <circle cx="50" cy="50" r="6" fill="white"/>
+  </svg>
+  <p class="loader-text">Loading Pokémon...</p>
+</div>
+
+<ul *ngIf="!isLoading && pokemonList && pokemonList.length > 0" class="pokemon-results">
     <li class="pokemon-figure" *ngFor="let pokemon of pokemonList">
         <pokemon-detail [detail]="pokemon"></pokemon-detail>
         <div class="pokemon-detail">
@@ -6,5 +17,3 @@
         </div>
     </li>
 </ul>
-
-<p>pokemonList.length {{ pokemonList?.length}}</p>

--- a/src/app/pokedex-dashboard/container/pokedex-dashboard/pokedex-dashboard.component.scss
+++ b/src/app/pokedex-dashboard/container/pokedex-dashboard/pokedex-dashboard.component.scss
@@ -11,4 +11,30 @@ ul {
     }
 }
 
+.loader-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem;
+}
+
+.pokeball-loader {
+    width: 80px;
+    height: 80px;
+    animation: spin 1s linear infinite;
+}
+
+.loader-text {
+    margin-top: 1rem;
+    font-size: 1.2rem;
+    font-weight: bold;
+    color: #333;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
 

--- a/src/app/pokedex-dashboard/container/pokedex-dashboard/pokedex-dashboard.component.ts
+++ b/src/app/pokedex-dashboard/container/pokedex-dashboard/pokedex-dashboard.component.ts
@@ -9,6 +9,7 @@ import { PokemonDetail } from '../../models/pokemon.interface';
 })
 export class PokedexDashboardComponent implements OnInit, OnChanges {
   @Input() pokemonList: PokemonDetail[] = [];
+  @Input() isLoading = false;
 
   constructor(private pokedexService: PokedexDashboardService) { }
 


### PR DESCRIPTION
Adds a spinning pokeball loader that displays while Pokemon cards are fetching from the API.

## Changes

- `PokedexContainerComponent` — added `isLoading` state, set to `true` on init and `false` once the API call completes
- `PokedexDashboardComponent` — added `@Input() isLoading`, shows pokeball SVG loader while true, shows pokemon list when false
- Inline SVG pokeball (red top, white bottom, black band & center button) with CSS `spin` keyframe animation (1s linear infinite)
- Removed debug paragraph showing pokemonList.length

Closes #9

Generated with [Claude Code](https://claude.ai/code)