### PR TITLE
feat: Incremental Pokémon loading with Load More button

### DIFF
--- a/src/app/pokedex-container/pokedex-container.component.html
+++ b/src/app/pokedex-container/pokedex-container.component.html
@@ -1,3 +1,9 @@
 <div class="container pokedex">
-<pokedex-dashboard [pokemonList]="pokemonList" [isLoading]="isLoading"></pokedex-dashboard>
+  <pokedex-dashboard
+    [pokemonList]="pokemonList"
+    [isLoading]="isLoading"
+    [isLoadingMore]="isLoadingMore"
+    [hasMore]="hasMore"
+    (loadMore)="loadMore()">
+  </pokedex-dashboard>
 </div>

--- a/src/app/pokedex-container/pokedex-container.component.ts
+++ b/src/app/pokedex-container/pokedex-container.component.ts
@@ -1,5 +1,8 @@
 import { Component, NgZone, OnInit } from '@angular/core';
-import  {PokedexDashboardService} from '../pokedex-dashboard/pokedex-dashboard.service';
+import { PokedexDashboardService } from '../pokedex-dashboard/pokedex-dashboard.service';
+import { PokemonDetail } from '../pokedex-dashboard/models/pokemon.interface';
+
+const PAGE_LIMIT = 24;
 
 @Component({
   selector: 'pokedex-container',
@@ -7,18 +10,33 @@ import  {PokedexDashboardService} from '../pokedex-dashboard/pokedex-dashboard.s
   styleUrls: ['./pokedex-container.component.scss']
 })
 export class PokedexContainerComponent implements OnInit {
-  pokemonList: any[] = [];
+  pokemonList: PokemonDetail[] = [];
   isLoading = true;
+  isLoadingMore = false;
+  hasMore = false;
+  private offset = 0;
 
   constructor(private pokedexService: PokedexDashboardService, private ngZone: NgZone) { }
 
   ngOnInit(): void {
-    this.pokedexService.getPokemon().subscribe((pokemonList) => {
+    this.loadPokemon();
+  }
+
+  loadMore(): void {
+    if (this.isLoadingMore || !this.hasMore) return;
+    this.isLoadingMore = true;
+    this.loadPokemon();
+  }
+
+  private loadPokemon(): void {
+    this.pokedexService.getPokemon(PAGE_LIMIT, this.offset).subscribe((page) => {
       this.ngZone.run(() => {
-        this.pokemonList = pokemonList;
+        this.pokemonList = [...this.pokemonList, ...page.pokemon];
+        this.hasMore = page.hasMore;
+        this.offset += PAGE_LIMIT;
         this.isLoading = false;
+        this.isLoadingMore = false;
       });
     });
   }
-
 }

--- a/src/app/pokedex-dashboard/container/pokedex-dashboard/pokedex-dashboard.component.html
+++ b/src/app/pokedex-dashboard/container/pokedex-dashboard/pokedex-dashboard.component.html
@@ -17,3 +17,23 @@
         </div>
     </li>
 </ul>
+
+<div *ngIf="!isLoading" class="load-more-container">
+  <div *ngIf="isLoadingMore" class="loader-container loader-container--inline">
+    <svg class="pokeball-loader pokeball-loader--small" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="50" cy="50" r="48" fill="white" stroke="black" stroke-width="4"/>
+      <path d="M2 50 Q2 2 50 2 Q98 2 98 50 Z" fill="#e3350d"/>
+      <rect x="2" y="44" width="96" height="12" fill="black"/>
+      <circle cx="50" cy="50" r="12" fill="white" stroke="black" stroke-width="4"/>
+      <circle cx="50" cy="50" r="6" fill="white"/>
+    </svg>
+    <p class="loader-text">Loading more Pokémon...</p>
+  </div>
+
+  <button
+    *ngIf="hasMore && !isLoadingMore"
+    class="load-more-btn"
+    (click)="onLoadMore()">
+    Load More Pokémon
+  </button>
+</div>

--- a/src/app/pokedex-dashboard/container/pokedex-dashboard/pokedex-dashboard.component.scss
+++ b/src/app/pokedex-dashboard/container/pokedex-dashboard/pokedex-dashboard.component.scss
@@ -37,4 +37,42 @@ ul {
     to { transform: rotate(360deg); }
 }
 
+.load-more-container {
+    display: flex;
+    justify-content: center;
+    padding: 2rem 1rem;
+}
+
+.loader-container--inline {
+    padding: 1rem;
+}
+
+.pokeball-loader--small {
+    width: 40px;
+    height: 40px;
+}
+
+.load-more-btn {
+    display: inline-block;
+    padding: 0.75rem 2.5rem;
+    background-color: #e3350d;
+    color: #fff;
+    font-size: 1rem;
+    font-weight: bold;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    transition: background-color 0.2s ease;
+
+    &:hover {
+        background-color: #b22a0a;
+    }
+
+    &:active {
+        background-color: #8c1f07;
+    }
+}
+
 

--- a/src/app/pokedex-dashboard/container/pokedex-dashboard/pokedex-dashboard.component.ts
+++ b/src/app/pokedex-dashboard/container/pokedex-dashboard/pokedex-dashboard.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
-import  {PokedexDashboardService} from '../../pokedex-dashboard.service';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
+import { PokedexDashboardService } from '../../pokedex-dashboard.service';
 import { PokemonDetail } from '../../models/pokemon.interface';
 
 @Component({
@@ -10,6 +10,9 @@ import { PokemonDetail } from '../../models/pokemon.interface';
 export class PokedexDashboardComponent implements OnInit, OnChanges {
   @Input() pokemonList: PokemonDetail[] = [];
   @Input() isLoading = false;
+  @Input() isLoadingMore = false;
+  @Input() hasMore = false;
+  @Output() loadMore = new EventEmitter<void>();
 
   constructor(private pokedexService: PokedexDashboardService) { }
 
@@ -22,4 +25,7 @@ export class PokedexDashboardComponent implements OnInit, OnChanges {
     }
   }
 
+  onLoadMore(): void {
+    this.loadMore.emit();
+  }
 }

--- a/src/app/pokedex-dashboard/models/pokemon.interface.ts
+++ b/src/app/pokedex-dashboard/models/pokemon.interface.ts
@@ -4,6 +4,8 @@ export interface PokemonListItem {
 }
 
 export interface Pokemon {
+  count: number,
+  next: string | null,
   results: PokemonListItem[],
 }
 

--- a/src/app/pokedex-dashboard/pokedex-dashboard.service.ts
+++ b/src/app/pokedex-dashboard/pokedex-dashboard.service.ts
@@ -6,10 +6,16 @@ import { catchError, map, switchMap } from 'rxjs/operators';
 
 const POKEDEX_API = 'https://pokeapi.co/api/v2/pokemon/';
 const POKEDEX_IMAGE_BASE_URL = 'https://assets.pokemon.com/assets/cms2/img/pokedex/detail/';
+const DEFAULT_LIMIT = 24;
 
 const getPokedexImageUrl = (id: number): string => {
     return `${POKEDEX_IMAGE_BASE_URL}${String(id).padStart(3, '0')}.png`;
 };
+
+export interface PokemonPage {
+    pokemon: PokemonDetail[];
+    hasMore: boolean;
+}
 
 @Injectable({
     providedIn: 'root'
@@ -17,8 +23,8 @@ const getPokedexImageUrl = (id: number): string => {
 export class PokedexDashboardService {
     constructor(private http: HttpClient){}
 
-    getPokemon(): Observable<PokemonDetail[]> {
-        return this.http.get<Pokemon>(POKEDEX_API).pipe(
+    getPokemon(limit: number = DEFAULT_LIMIT, offset: number = 0): Observable<PokemonPage> {
+        return this.http.get<Pokemon>(`${POKEDEX_API}?limit=${limit}&offset=${offset}`).pipe(
             switchMap((response) => {
                 const detailRequests = response.results.map((item) =>
                     this.http.get<PokemonDetail>(`${POKEDEX_API}${item.name}`).pipe(
@@ -29,12 +35,16 @@ export class PokedexDashboardService {
                         catchError(() => of(null))
                     )
                 );
-                return forkJoin(detailRequests);
+                return forkJoin(detailRequests).pipe(
+                    map((results) => ({
+                        pokemon: results.filter((item): item is PokemonDetail => item !== null),
+                        hasMore: response.next !== null,
+                    }))
+                );
             }),
-            map((results) => results.filter((item): item is PokemonDetail => item !== null)),
             catchError((error) => {
                 console.error('getPokemon error:', error);
-                return of([]);
+                return of({ pokemon: [], hasMore: false });
             })
         );
     }


### PR DESCRIPTION
Implements incremental loading of Pokémon data with a "Load More" button, matching the behavior of the official Pokémon Pokédex page.

## Changes
- Service supports pagination (limit/offset) via PokeAPI params
- Component appends new results instead of replacing them
- "Load More Pokémon" button triggers next page load
- Inline pokeball spinner shown while loading more

Closes #11

Generated with [Claude Code](https://claude.ai/code)