### PR TITLE
fix: enforce patched node-forge version to fix GHSA-5gfm-wpxj-wjgq

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "tslib": "^2.3.0",
     "zone.js": "~0.14.10"
   },
+  "overrides": {
+    "node-forge": ">=1.3.1"
+  },
   "devDependencies": {
     "@angular-devkit/build-angular": "^17.3.17",
     "@angular/cli": "^17.3.17",


### PR DESCRIPTION
Fixes #13

Adds npm `overrides` in package.json to enforce node-forge >=1.3.1 for all transitive dependencies, addressing the GHSA-5gfm-wpxj-wjgq Interpretation Conflict vulnerability via ASN.1 Validator Desynchronization.

After merging, run `npm install` to regenerate package-lock.json with the enforced version.

Generated with [Claude Code](https://claude.ai/code)