### PR TITLE
fix: resolve GHSA-r5fr-rjxr-66jc esbuild security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "test": "ng test"
   },
   "private": true,
+  "overrides": {
+    "esbuild": ">=0.25.0"
+  },
   "dependencies": {
     "@angular/animations": "^17.3.12",
     "@angular/common": "^17.3.12",


### PR DESCRIPTION
Fixes #17

## Summary

- Adds npm `overrides` to `package.json` to force `esbuild >= 0.25.0`
- Addresses GHSA-r5fr-rjxr-66jc: esbuild enables any website to send requests to the development server
- Previously installed version was 0.20.1 (vulnerable)

## Steps After Merge

Run `npm install` locally to update `package-lock.json` with the patched esbuild version.

Generated with [Claude Code](https://claude.ai/code)